### PR TITLE
Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "metrics",
   "description": "Modified version of 'metrics' npm module",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "repository": {
     "type": "git",
     "url": "git://github.com/harisiva/metrics.git"


### PR DESCRIPTION
npm apparently won't update a git dependency even if the commit hash changes in `package.json`, unless the version also changes.  bumping the version and updating `package.json` should fix anyone's machine that has an outdated version of the package.